### PR TITLE
Added workshop-manager to container and therefore dependencies on zlib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,17 @@
 FROM php:7-cli
 MAINTAINER Rafael Corrêa Gomes <rafaelcg_stz@hotmail.com>
 
+
 RUN apt-get update \
   && apt-get install -y \
     apt-utils \
     zip \
     git \
-    vim
+    vim \
+    libzip-dev \
+    zlib1g-dev \
+  && docker-php-ext-configure zip --with-zlib-dir=/usr \
+  && docker-php-ext-install -j$(nproc) zip 
 
 # Composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
@@ -30,6 +35,13 @@ RUN mkdir /phpschool/callablefunctions \
     && cd /phpschool/callablefunctions \
     && composer init -q -n \
     && composer require nastasia/callable-functions
+
+# Workshop manager 
+RUN mkdir /phpschool/workshop-manager \
+    && cd /phpschool/workshop-manager \
+    && curl -O https://php-school.github.io/workshop-manager/workshop-manager.phar \
+    && mv workshop-manager.phar /usr/local/bin/workshop-manager \
+    && chmod +x /usr/local/bin/workshop-manager 
 
 WORKDIR /phpschool
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ![PHPSchool.io](https://avatars1.githubusercontent.com/u/14904751?v=3&s=200)
 
+Creates a docker container with the learnyouphp, Callable functions workshops and the workshop manager.
+
 To start you may execute these commands in the Docker image folder.
 
 **1. Build the image.**


### PR DESCRIPTION
Hi I wanted to run the container but still have the use of the workshop manager so I included it in the same container. Be grateful if this was merged back as I am sure others may want to do the same.
